### PR TITLE
Sección Denuncias, icono de WhattsApp

### DIFF
--- a/projects/caballos-en-libertad/pages/denuncias.html
+++ b/projects/caballos-en-libertad/pages/denuncias.html
@@ -3,7 +3,10 @@
 <html>
     <head>
         <meta charset="utf-8">
-        <title>Caballos en libertad</title>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <title>Caballos en libertad | Denuncias</title>
         
         <!-- Bootstrap-->
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">


### PR DESCRIPTION
- Agregadas 2 líneas de código en denuncias.html para arreglar dimenciones del icono de WhattsApp en la vista de movíl.
- Cambiado el nombre en la etiqueta <tittle>.
- Las dimensiones del texto y cuadros de la página denuncias se han desconfigurado (falta por arreglar).