### PR TITLE
HFAID - About us - Fix (Mobile)

### DIFF
--- a/projects/human-front-aid/css/about-us.css
+++ b/projects/human-front-aid/css/about-us.css
@@ -44,31 +44,119 @@ header {
     text-align: justify;
     height: auto;
     padding: 0px 40px;
+    
 }
 
 .about-us-main-img {
     display: flex;
-    max-width: 100%;
+    max-width: 90%;
     margin-bottom: 50px;
     border-radius: 10px;
 }
 
 
-.about-us-main {
-    margin-bottom: 100px;
+/*La regla @media screen permite generar diferentes dispocion segun el tamño de la pantall*/
+
+
+/*posicion en mobile*/
+@media screen and (max-width: 480px) {
+    .position-of-image1 {
+      position: relative;
+      width: 90%;
+      margin-left: 10%;
+      margin-top: 10%;
+
+    }
+    .about-us-text1 {
+        font-size: 120%;
+        margin-bottom: 30px;
+        margin-top: 10%;
+        left: 50%;
+        
+    }
+    .history-titulo {
+        color: var(--color-dos);
+        font-family: var(--font-family-lato);
+        font-weight: 570;
+        margin-bottom: 5%;
+        font-size: 200%;
+        margin-left: 13%;
+    }
+
+    .position-of-image2 {
+        position: relative;
+        width: 90%;
+        margin-left: 10%;
+  
+      }
+      .about-us-text2 {
+        font-size: 120%;
+        margin-bottom: 30px;
+        margin-top: 0px;
+        left: 50%;
+          
+      }
+  }
+  /*posicion en desktop*/
+  @media screen and (min-width: 481px) {
+    .position-of-image1 {
+       position: relative;
+       margin-bottom: 5%;
+       margin-top: 50px;
+       left: 45%;
+       right: auto;    
+    }
+    .about-us-text1 {
+        position: relative;
+        font-size: 120%;
+        margin-bottom: 5%;
+        margin-top: 50px;
+        left: auto;
+        right: 45%;
+        margin-left: 10%;
+       
+    
+    }
+
+    .history-titulo {
+        color: var(--color-dos);
+        font-family: var(--font-family-lato);
+        font-weight: 570;
+        margin-bottom: 2%;
+        
+        margin-left: 10%;
+    }
+    
+    .position-of-image2 {
+        position: relative;
+        margin-bottom: 0%;
+        margin-top: 0%;
+        left: auto;
+        right: 45%;
+        margin-left: 12%;
+
+    }
+    .about-us-text2 {
+
+        position: relative;
+        font-size: 120%;
+        margin-bottom: 0%;
+        margin-top: 0%;
+        left: 45%;
+        right: auto; 
+    }
    
+  }
+.about-us-main {
+    margin-bottom: 20px;
+    
 }
 
 .about-us-history-img {
     max-width: 150%;
 }
 
-.history-titulo {
-    color: var(--color-dos);
-    font-family: var(--font-family-lato);
-    font-weight: 570;
-    margin-bottom: 50px;
-}
+
     
 /* ┌─────────────────────────────────────────────────────────┐ */
 /* │ ■■■■■■■■■■■■■■■■■■■■ FIN ABOUT-US ■■■■■■■■■■■■■■■■■■■■■ │ */
@@ -137,17 +225,7 @@ header {
         margin-left: 0px;
         margin-right: 0px; 
     }
-
-    .history-titulo {
-        font-size: 250%;
-        margin-bottom: 30px;
-    }
-
-    .about-us-text {
-        font-size: 120%;
-        margin-bottom: 30px;
-        margin-top: 50px       
-    }
+  
 
     .about-us-main-img {
         margin-bottom: 20px;
@@ -207,16 +285,12 @@ header {
         margin-right: 10px;
     }
 
-    .about-us-text {
-        margin-bottom: 30px;
-        margin-top: 50px;
-    }
-
     .history-titulo {
         font-size: 250%;
     }
 
     .about-us-main-img {
+
         margin-bottom: 30px;
     }
 

--- a/projects/human-front-aid/pages/about-us.html
+++ b/projects/human-front-aid/pages/about-us.html
@@ -287,14 +287,20 @@
     <!-- └─────────────────────────────────────────────────────────┘ -->
     
     <section class="about-us container-fluid">
+
         <div class="row col-12 about-us-main">
-            <div class="col-lg-5 col-md-5 col-12 offset-lg-1 offset-md-1 about-us-text">
+            <div class="col-lg-5 col-md-5 col-12 position-of-image1">
+                <img class="about-us-main-img" src="../img/about-us-history-01-change.png" alt="" />
+            </div>
+            <div class="col-lg-5 col-md-5 col-12 offset-lg-1 offset-md-1 about-us-text1">
+
                 <p data-translate="aboutUsparagraph1">
                     We are a non-bureaucratic non-profit organization, momentarily
                     working to support the Ukrainian victims of the war. The
                     co-operation with local partners in Odesa assures that we can move
                     fast and adapt to the current situation on the ground.
                 </p>
+
                 <p data-translate="aboutUsparagraph2">
                     Our intention is to support projects regionally and locally. They
                     know best what is required at any moment, and we believe this is a
@@ -306,22 +312,16 @@
                     most effective manner.
                 </p>
             </div>
-
-            <div class="col-lg-5 col-md-5 col-12">
-                <img class="about-us-main-img" src="../img/about-us-history-01-change.png" alt="" />
-            </div>
-
+            
         </div>
 
-    <h2 class="offset-1  history-titulo" data-translate="aboutHistory">History</h2>
+        <h2 class="offset-1  history-titulo" data-translate="aboutHistory">History</h2>
 
-        <div class="row col-12 about-us-main">
+        <div class="row col-12 about-us-main"> 
+   
+            
 
-            <div class="col-lg-5 col-md-5 col-12 offset-lg-1 offset-md-1">
-                <img class="about-us-main-img" src="../img/about-us-history-02.png" alt="" />
-            </div>
-
-            <div class="col-lg-5 col-md-5 col-12 about-us-text">
+            <div class="col-lg-5 col-md-5 col-12 about-us-text2">
                 <p data-translate="aboutHistoryUsparagraph1">
                     When the conflict started the Swiss Bänz Margot fled from Odesa to
                 Moldova trying to find ways of helping from there. Visiting refugee
@@ -337,7 +337,13 @@
                     people from places under occupation and the front line.
                 </p>
             </div>
+            <div class="col-lg-5 col-md-5 col-12 offset-lg-1 offset-md-1 position-of-image2">
+                <img class="about-us-main-img" src="../img/about-us-history-02.png" alt="" />
+            </div>
+
         </div>
+
+
 
     </section>
 


### PR DESCRIPTION
Se creo una regla en el CSS para diferenciar la dispocicon de texto e imágenes según si el ancho de la pantalla es mayor a 480 pixels (desktop) o igual o menor (mobile). Esto se realizo para que la disposición final se asimilara al Figma. 
Los cambios que se realizaron para esto fueron:
-Crear regla de media mediante los indicadores “@media screen and (max-width: 480px)” y “@media screen and (min-width: 481px)”.
-remplazar id “about-us-text” por “about-us-text1” y “about-us-text2” respectivamente
-crear etiquete “position-of-image1” y “position-of-image2”
- introducir los id previamente mencionados junto con el id “history-titulo” en las reglas de mobile y desktop. 
- ajustar la disposición de los elementos para que su posición, tamaño y apariencia en general se asemeje al Figma.
